### PR TITLE
update sicm_arena alloc and realloc to behave nicely with size = 0

### DIFF
--- a/src/low/sicm_arena.c
+++ b/src/low/sicm_arena.c
@@ -293,6 +293,10 @@ void *sicm_arena_alloc(sicm_arena a, size_t sz) {
 	sarena *sa;
 	int flags;
 
+	if (sz == 0) {
+		return je_malloc(0);
+	}
+
 	sa = a;
 	flags = 0;
 	if (sa != NULL) {
@@ -305,29 +309,30 @@ void *sicm_arena_alloc(sicm_arena a, size_t sz) {
 void *sicm_arena_alloc_aligned(sicm_arena a, size_t sz, size_t align) {
 	sarena *sa;
 	int flags;
-	void *ret;
 
 	sa = a;
 	flags = 0;
 	if (sa != NULL)
 		flags = MALLOCX_ARENA(sa->arena_ind) | MALLOCX_TCACHE_NONE | MALLOCX_ALIGN(align);
 
-	ret = je_mallocx(sz, flags);
-	return ret;
+	return je_mallocx(sz, flags);
 }
 
 void *sicm_arena_realloc(sicm_arena a, void *ptr, size_t sz) {
 	sarena *sa;
 	int flags;
-	void *ret;
+
+	if (sz == 0) {
+		sicm_free(ptr);
+		return NULL;
+	}
 
 	sa = a;
 	flags = 0;
 	if (sa != NULL)
 		flags = MALLOCX_ARENA(sa->arena_ind) | MALLOCX_TCACHE_NONE;
 
-	ret = je_rallocx(ptr, sz, flags);
-	return ret;
+	return je_rallocx(ptr, sz, flags);
 }
 
 void *sicm_alloc(size_t sz) {

--- a/src/low/sicm_low.c
+++ b/src/low/sicm_low.c
@@ -112,7 +112,6 @@ struct sicm_device_list sicm_init() {
   struct bitmask* cpumask = numa_allocate_cpumask();
   int cpu_count = numa_num_possible_cpus();
   struct bitmask* compute_nodes = numa_bitmask_alloc(node_count);
-  printf("Bitmask size: %lu\n", cpumask->size);
   i = 0;
   for(i = 0; i < node_count; i++) {
     numa_node_to_cpus(i, cpumask);


### PR DESCRIPTION
[malloc(3)](https://linux.die.net/man/3/malloc)

> The malloc() function allocates size bytes and returns a pointer to the allocated memory. The memory is not initialized. **If size is 0, then malloc() returns either NULL, or a unique pointer value that can later be successfully passed to free()**.

Umpire wants a unique pointer that can be passed to free().

> The realloc() function changes the size of the memory block pointed to by ptr to size bytes. The contents will be unchanged in the range from the start of the region up to the minimum of the old and new sizes. If the new size is larger than the old size, the added memory will not be initialized. If ptr is NULL, then the call is equivalent to malloc(size), for all values of size; **if size is equal to zero, and ptr is not NULL, then the call is equivalent to free(ptr).** Unless ptr is NULL, it must have been returned by an earlier call to malloc(), calloc() or realloc(). If the area pointed to was moved, a free(ptr) is done.