### PR TITLE
sicm_device_list initialization and other fixes

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -4,6 +4,9 @@ project (SICM)
 # Use -DSICM_BUILD_HIGH_LEVEL=True to build the high-level interface.
 set(SICM_BUILD_HIGH_LEVEL False CACHE BOOL "Should we build the high-level interface?")
 
+find_package(Threads REQUIRED)
+link_libraries(Threads::Threads m dl)
+
 # Install custom CMake modules for jemalloc and libnuma.
 set(CMAKE_MODULE_PATH ${CMAKE_MODULE_PATH} "${CMAKE_SOURCE_DIR}/cmake/Modules/")
 

--- a/include/low/public/sicm_low.h
+++ b/include/low/public/sicm_low.h
@@ -39,20 +39,17 @@ sicm_device_tag sicm_get_device_tag(char *env);
 
 /// Data specific to a DRAM device.
 typedef struct sicm_dram_data {
-  int node; ///< NUMA node
   int page_size; ///< Page size
 } sicm_dram_data;
 
 /// Data specific to a KNL HBM device.
 typedef struct sicm_knl_hbm_data {
-  int node; ///< NUMA node
   int compute_node;
   int page_size; ///< Page size
 } sicm_knl_hbm_data;
 
 /// Data specific to a PowerPC 9 HBM device.
 typedef struct sicm_powerpc_hbm_data {
-  int node;
   int page_size;
 } sicm_powerpc_hbm_data;
 
@@ -77,13 +74,14 @@ typedef union sicm_device_data {
  * operations.
  */
 typedef struct sicm_device {
-  sicm_device_tag tag; ///< Type of memory device
+  sicm_device_tag tag;   ///< Type of memory device
+  int node;              ///< NUMA node
   sicm_device_data data; ///< Per-type identifying information
 } sicm_device;
 
 /// Explicitly-sized sicm_device array.
 typedef struct sicm_device_list {
-  unsigned int count; ///< Number of devices in the array.
+  unsigned int count;   ///< Number of devices in the array.
   sicm_device* devices; ///< Array of devices of count elements.
 } sicm_device_list;
 
@@ -92,10 +90,10 @@ typedef struct sicm_device_list {
  * All times are in milliseconds.
  */
 struct sicm_timing {
-  unsigned int alloc; ///< Time requried for allocation.
-  unsigned int write; ///< Time required for writing.
-  unsigned int read; ///< Time required for reading.
-  unsigned int free; ///< Time required for deallocation.
+  unsigned int alloc;   ///< Time requried for allocation.
+  unsigned int write;   ///< Time required for writing.
+  unsigned int read;    ///< Time required for reading.
+  unsigned int free;    ///< Time required for deallocation.
 };
 
 /// Handle to an arena.


### PR DESCRIPTION
link pthreads, m, and dl in cmake
moved NUMA node number into sicm_device so that it can be accessed without code paths for each device type
initialize sicm_device_list so that it starts at invalid values instead of 0, which is valid
device count is count of valid devices, not all possible devices - actual device list size is count + 1
resize device list at the end to save some space
last device is set to invalid