### PR TITLE
Fix Invalid Write

### DIFF
--- a/src/low/sicm_low.c
+++ b/src/low/sicm_low.c
@@ -81,7 +81,7 @@ struct sicm_device_list sicm_init() {
 
   struct bitmask* non_dram_nodes = numa_bitmask_alloc(node_count);
 
-  struct sicm_device* devices = malloc(device_count * sizeof(struct sicm_device));
+  struct sicm_device* devices = malloc((device_count + 1) * sizeof(struct sicm_device));
   int* huge_page_sizes = malloc(huge_page_size_count * sizeof(int));
 
   int i, j;


### PR DESCRIPTION
Intentionally create one extra device (for the "NULL terminator" at the end of the array), just in case all devices are valid and realloc is not done