### PR TITLE
Update spack package

### DIFF
--- a/spack-repo/packages/sicm-low/package.py
+++ b/spack-repo/packages/sicm-low/package.py
@@ -16,7 +16,7 @@ class SicmLow(CMakePackage):
 
     version('master')
 
-    depends_on('jemalloc +je')
+    depends_on('jemalloc jemalloc_prefix=je_')
     depends_on('numactl')
 
     def cmake_args(self):

--- a/spack-repo/repo.yaml
+++ b/spack-repo/repo.yaml
@@ -1,2 +1,2 @@
 repo:
-  namespace: 'spack'
+  namespace: 'SICM'


### PR DESCRIPTION
jemalloc_prefix can be specified with spack variant (https://github.com/spack/spack/pull/18680)
repo namespace changed to SICM

